### PR TITLE
Clear old repeat timer if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,9 @@ function isItTime (app, props){
 }
 
 function repeat(app, props, lightLevel){
+  if (repeatTimer) {
+    clearInterval(repeatTimer)
+  }
   repeatTimer = setInterval(function() {
     if (props.Seatalk1){
       seatalkCommand = seaTalk[lightLevel]


### PR DESCRIPTION
If old repeat timer is not cleared, then on each check of the time of the day an additional timer is created, so over time it accumulates all created timers and as a result instead of single message sent every 30 seconds it sends out bursts of tens or even hundreeds of messages at a time. Things start to get especially messy when there are messages with different light level in the same burst...